### PR TITLE
Add host descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,32 @@ The script works over SSH with SSH public keys for secure authentication and tra
 ## Hosts config file ##
 Each line of the config file should contain the hostname or IP of a pfSense router/firewall. 
 Optionally follow the hostname with colon port numnber if SSH is not on the default TCP port 22.
-#####Example hosts.conf file with 3 entries. Note the first entry with non-standard SSH port:
+
+Format of the hosts.conf entries `<hostname>:<port>:<description>`
+
+##### Example hosts.conf file with 3 entries. Note the first entry with non-standard SSH port:
     10.10.1.1:80 
     pfsense.example.com
     207.123.123.4
+    10.20.1.1::pfsense
 
 ## SSH setup on your side ##
 If SSH keys are new to you, there are lots of good resources just a Google away ;)
-#####Nonetheless, here is the quick version:
+##### Nonetheless, here is the quick version:
 	- Run ssh-keygen from the command line on the [Mac / Linux] box doing the backups.
 	- Copy the content from id_rsa.pub and paste it into the "Authorized keys" field in pfSense (see below.)
-#####Setup your ~/.ssh/config file to pass the correct identity for your backup user:
+##### Setup your ~/.ssh/config file to pass the correct identity for your backup user:
     Host *
     User backup
     IdentityFile ~/.ssh/backup-user.rsa
 
 ## SSH Setup on the pfSense box ##
-#####Enable SSH:
+##### Enable SSH:
 	- Log into your pfSense via the web interface.
 	- Advanced -> Secure Shell Server -> Check the "Enable Secure Shell" box.
 	- Note the port, if this is not the default, you will need to specify it in the hosts config.
 	- Save your changes.
-#####Add a backup user and SSH key:
+##### Add a backup user and SSH key:
 	- Log into your pfSense via the web interface.
 	- System -> User Manager
 	- Click the + to add new user.
@@ -46,8 +50,7 @@ If SSH keys are new to you, there are lots of good resources just a Google away 
 If you can SSH into each pfSense box as the backup user without having to enter a password then you are ready to run the script.
 
 ## The backups ##
-Backups are created with the host name (from the config file) followed by a timestamp.
-
+Backups are created from the description and host name (from the config file) followed by a timestamp.
 
 Enjoy :)
 

--- a/README.md
+++ b/README.md
@@ -22,29 +22,36 @@ Format of the hosts.conf entries `<hostname>:<port>:<description>`
 
 ## SSH setup on your side ##
 If SSH keys are new to you, there are lots of good resources just a Google away ;)
+
 ##### Nonetheless, here is the quick version:
-	- Run ssh-keygen from the command line on the [Mac / Linux] box doing the backups.
-	- Copy the content from id_rsa.pub and paste it into the "Authorized keys" field in pfSense (see below.)
+- Run ssh-keygen from the command line on the [Mac / Linux] box doing the backups.
+- Copy the content from id_rsa.pub and paste it into the "Authorized keys" field in pfSense (see below.)
+
 ##### Setup your ~/.ssh/config file to pass the correct identity for your backup user:
-    Host *
+```
+Host *
     User backup
     IdentityFile ~/.ssh/backup-user.rsa
+```
 
 ## SSH Setup on the pfSense box ##
+
 ##### Enable SSH:
-	- Log into your pfSense via the web interface.
-	- Advanced -> Secure Shell Server -> Check the "Enable Secure Shell" box.
-	- Note the port, if this is not the default, you will need to specify it in the hosts config.
-	- Save your changes.
+- Log into your pfSense via the web interface.
+- Advanced -> Secure Shell Server -> Check the "Enable Secure Shell" box.
+- Note the port, if this is not the default, you will need to specify it in the hosts config.
+- Save your changes.
+
 ##### Add a backup user and SSH key:
-	- Log into your pfSense via the web interface.
-	- System -> User Manager
-	- Click the + to add new user.
-	- Enter username and a secure password (you don't need to remember the password but it is required by the form.)
-	- Full Name -> Enter "Backup User"
-	- Click on "admins" under "Not Member Of" and move it to the "Member of" box to make your backup user an admin.
-	- Authorized keys -> Check this box and paste in your SSH public key from above.
-	- Save your changes.
+
+- Log into your pfSense via the web interface.
+- System -> User Manager
+- Click the + to add new user.
+- Enter username and a secure password (you don't need to remember the password but it is required by the form.)
+- Full Name -> Enter "Backup User"
+- Click on "admins" under "Not Member Of" and move it to the "Member of" box to make your backup user an admin.
+- Authorized keys -> Check this box and paste in your SSH public key from above.
+- Save your changes.
 
 ## Testing your setup ##
 If you can SSH into each pfSense box as the backup user without having to enter a password then you are ready to run the script.

--- a/etc/pfmb/hosts.conf
+++ b/etc/pfmb/hosts.conf
@@ -1,2 +1,3 @@
 pfsense.example.com
 10.10.1.1:80
+10.20.1.1:443:virtual_pfsense

--- a/usr/local/bin/pfmb
+++ b/usr/local/bin/pfmb
@@ -8,13 +8,21 @@
 # Give useful feedback on errors relating to SSH / connectivity.
 # Allow different SSH keys for each IP.
 
-source /etc/default/pfmb
+if [[ -r "/etc/default/pfmb" ]] ; then
+  source /etc/default/pfmb
+fi
+
+##### Defaults when there are no defaults
+: ${config:=/etc/pfmb/hosts.conf}
+: ${backupuser:=backup}
+: ${backupdir:=/var/backups/pfmb}
+: ${backupcopies:=25}
 
 ##### Other settings - don't change these willy-nilly unless you know what you're doing! #####
 datestamp=$(date '+%Y-%m-%d-%s')
 
 # Path on pfSense to the XML configuration file.
-xmlpath="/cf/conf/config.xml"
+: ${xmlpath:=/cf/conf/config.xml}
 
 function isint() {
   re='^[0-9]+$'
@@ -24,33 +32,47 @@ function isint() {
 }
 
 function rotateBackups() {
-  files=$(ls $backupdir/*$1-*xml | sort | tail -n $backupcopies)
-  for i in $backupdir/*$1-*xml; do
-    keep=0;
+  OLDIFS=$IFS
+  IFS=$'\n'
+  files=$(find "$backupdir" -name "$1-*xml" | sort | tail -n $backupcopies)
+  find "$backupdir" -name "$1-*xml" | while read i; do
+    keep=0
     for a in ${files[@]}; do
-      if [ $i == $a ]; then
+      echo $a
+      if [ "$i" == "$a" ]; then
         keep=1;
       fi
-    done;
+    done
     if [ $keep == 0 ]; then
-      rm $i
+      rm "$i"
     fi
   done
+  IFS=$OLDIFS
 }
 
 function main() {
-  while IFS=':' read -r host port ; do
+  while IFS=':' read -r host port desc; do
     if [ -n "$port" ] ; then
       isint $port
     else
       port=22
     fi
-    scp -q -P $port $backupuser@$host:$xmlpath "$backupdir/$host-$datestamp.xml"
-    if [ $? -eq 0 ] && [ -s "$backupdir/$host-$datestamp.xml" ]; then
-      echo "Backing up $host..."
-      rotateBackups $host
+
+    # setup vars for use
+    name="$host"
+    if [[ ! -z "$desc" ]] ; then
+        name="$desc"
+        desc="$desc-"
+    fi
+    backup_file="$backupdir/$desc$host-$datestamp.xml"
+
+    # run the backups
+    scp -q -P $port $backupuser@$host:$xmlpath "${backup_file}"
+    if [ $? -eq 0 ] && [ -s "${backup_file}" ]; then
+      echo "Backing up $name... OK"
+      rotateBackups "$desc$host"
     else
-      echo "Backup on $host unsuccessfull"
+      echo "Backing up $name... FAILED"
     fi
   done < $config
 }


### PR DESCRIPTION
This allows users to specify host descriptions to be used in the output and in the names of the files.

`<hostname_or_ip>:<port_or_empty>:<description>`

The `description` field allows spaces.

Also updated the readme